### PR TITLE
Deployment of Documentation via GiHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,25 @@
+name: Docs
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          apt-get install graphviz doxygen
+          pip install breathe==4.34.0 myst==1.0.4 myst_parser==0.18.0 sphinx==5.0.2 sphinxcontrib-bibtexi==2.5.0 sphinx-rtd-theme==1.0.0
+      - name: Sphinx build
+        run: |
+          sphinx-build Doc _build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/HiRep-CUDA' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y graphviz doxygen
-          pip install breathe==4.34.0 myst==1.0.4 myst_parser==0.18.0 sphinx==5.0.2 sphinxcontrib-bibtexi==2.5.0 sphinx-rtd-theme==1.0.0
+          pip install breathe==4.34.0 myst==1.0.4 myst_parser==0.18.0 sphinx==5.0.2 sphinxcontrib-bibtex==2.5.0 sphinx-rtd-theme==1.0.0
       - name: Sphinx build
         run: |
           sphinx-build Doc _build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          apt-get install graphviz doxygen
+          sudo apt-get update && sudo apt-get install -y graphviz doxygen
           pip install breathe==4.34.0 myst==1.0.4 myst_parser==0.18.0 sphinx==5.0.2 sphinxcontrib-bibtexi==2.5.0 sphinx-rtd-theme==1.0.0
       - name: Sphinx build
         run: |

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -2,8 +2,13 @@
 
 import os
 import sys
+import subprocess
+from sphinx.builders.html import StandaloneHTMLBuilder
 
 sys.path.insert(0, os.path.abspath(".."))
+
+subprocess.call("make clean", shell=True)
+subprocess.call("cd ./doxygen ; doxygen Doxyfile", shell=True)
 
 # -- General configuration ------------------------------------------------
 extensions = [
@@ -125,11 +130,6 @@ texinfo_documents = [
 ]
 
 # -- Extension configuration -------------------------------------------------
-import subprocess
-
-subprocess.call("make clean", shell=True)
-subprocess.call("cd doxygen ; doxygen", shell=True)
-
 breathe_projects = {"HiRep": "doxygen/build/xml/"}
 breathe_default_project = "HiRep"
 

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -1,4 +1,6 @@
+breathe==4.34.0
 myst==1.0.4
 myst_parser==0.18.0
 sphinx==5.0.2
 sphinx-rtd-theme==1.0.0
+sphinxcontrib-bibtexi==2.5.0


### PR DESCRIPTION
This workflow builds the HiRep documentation using GitHub actions.

The documentation is built with Sphinx and saved in the `gh-pages` branch.

Check the example in my fork of the HiRep repository;

https://emolinaro.github.io/HiRep/

