### PR TITLE
Improved structure for exponential clover utils

### DIFF
--- a/Include/Utils/clover_exp.h
+++ b/Include/Utils/clover_exp.h
@@ -17,24 +17,15 @@ visible void _su2Nfc_times_su2Nfc_trace(hr_complex *trace, suNfc *B, suNfc *A);
 visible void _su2Nfc_times_su2Nfc_trace_herm_sq(hr_complex *trace, suNfc *B);
 visible void _su2Nfc_unit(suNfc *A);
 visible void _su2Nfc_trace(hr_complex *p, suNfc *A);
-void factorialCoef(double *C, int NN, int NNexp);
+visible void factorialCoef(double *C, int NNexp);
 
-#if !(NF == 2) && !(NF == 3)
-#define clover_exp clover_exp_taylor
-#else
-void clover_exp(suNfc *Aplus, suNfc *expAplus);
-#endif
-void clover_exp_taylor(suNfc *Aplus, suNfc *expAplus);
+visible void clover_exp(suNfc *Aplus, suNfc *expAplus, int NN);
+visible void clover_exp_taylor(suNfc *Aplus, suNfc *expAplus);
+visible void doublehorner(double *C, suNfc *A, int NNexp);
+
 void evaluate_sw_order(double *mass);
-void doublehorner(double *C, suNfc *A);
-
-void init_clover_exp();
 int get_NNexp();
 int get_NN();
-
-#ifdef WITH_GPU
-deviceonly void clover_exp_gpu(suNfc *Aplus, suNfc *expAplus, int NN, int NNexp);
-#endif
 
 #ifdef __cplusplus
 }

--- a/Include/Utils/factorial.h
+++ b/Include/Utils/factorial.h
@@ -8,19 +8,13 @@
 
 #include "libhr_core.h"
 
-#define MAX_FACTORIAL 100
-// To match with clover exp
-// But for the exp in the field update
-// we need only 30
+#define MAX_FACTORIAL 30 // This can be at most 50
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void init_factorial(void);
-void finalize_factorial(void);
-double inverse_factorial(int);
-deviceonly double inverse_factorial_gpu(int);
+visible double inverse_fact(int);
 
 #ifdef __cplusplus
 }

--- a/LibHR/Update/Dphi.c
+++ b/LibHR/Update/Dphi.c
@@ -1629,8 +1629,6 @@ void Cphi_cpu_(double mass, spinor_field *dptr, spinor_field *sptr, int assign, 
         mass = 1 / mass;
     }
 
-    init_clover_exp();
-
     // Loop over local sites
     _MASTER_FOR(dptr->type, ix) {
         suNfc Aplus[4];
@@ -1666,8 +1664,8 @@ void Cphi_cpu_(double mass, spinor_field *dptr, spinor_field *sptr, int assign, 
 
         // Exponentiate Aplus Aminus
 
-        clover_exp(Aplus, expAplus);
-        clover_exp(Aminus, expAminus);
+        clover_exp(Aplus, expAplus, get_NN());
+        clover_exp(Aminus, expAminus, get_NN());
 
         // Correct factor (4+m)
 

--- a/LibHR/Update/Dphi_gpu_kernels.hpp
+++ b/LibHR/Update/Dphi_gpu_kernels.hpp
@@ -518,8 +518,8 @@ __global__ void Cphi_gpu_kernel_(SITE_TYPE *dptr, SITE_TYPE *sptr, suNfc *cl_ter
         _suNfc_dagger(Aminus[2], Aminus[1]);
         _suNfc_mul(Aminus[3], -invexpmass, s2);
 
-        clover_exp_gpu(Aplus, expAplus, NN_loc, NNexp_loc);
-        clover_exp_gpu(Aminus, expAminus, NN_loc, NNexp_loc);
+        clover_exp(Aplus, expAplus, NN_loc);
+        clover_exp(Aminus, expAminus, NN_loc);
 
         _suNfc_mul_assign(expAplus[0], mass);
         _suNfc_mul_assign(expAplus[1], mass);

--- a/LibHR/Update/TMPL/Dphi_gpu.cu.tmpl
+++ b/LibHR/Update/TMPL/Dphi_gpu.cu.tmpl
@@ -311,8 +311,6 @@ void _GPU_F_NAME_(Cphi, _SUFFIX)(double mass, _FIELD_TYPE *dptr, _FIELD_TYPE *sp
         mass = 1 / mass;
     }
 
-    init_clover_exp();
-
     int NN_loc = get_NN();
     int NNexp_loc = get_NNexp();
 

--- a/LibHR/Update/clover_tools.c
+++ b/LibHR/Update/clover_tools.c
@@ -333,10 +333,6 @@ void clover_init_cpu(double csw) {
     sigma = 0xF00F;
     csw_value = csw;
     lprintf("CLOVER", 10, "Initial Coefficient: csw = %1.6f\n", csw_value);
-
-#if defined(WITH_EXPCLOVER)
-    init_clover_exp();
-#endif
 }
 
 #ifndef WITH_GPU

--- a/LibHR/Update/clover_tools_gpu.cu
+++ b/LibHR/Update/clover_tools_gpu.cu
@@ -405,10 +405,6 @@ void clover_init_gpu(double csw) {
     sigma = 0xF00F;
     csw_value = csw;
     lprintf("CLOVER", 10, "Initial Coefficient: csw = %1.6f\n", csw_value);
-
-#if defined(WITH_EXPCLOVER)
-    init_clover_exp();
-#endif
 }
 
 void set_csw_gpu(double *csw) {

--- a/LibHR/Update/force_fermion_core.c
+++ b/LibHR/Update/force_fermion_core.c
@@ -459,8 +459,8 @@ void force_clover_fermion(spinor_field *Xs, spinor_field *Ys, double residue) {
         _suNf_mul(Aminus[3], -invexpmass, *s2);
 
         // double horner scheme
-        doublehorner(Cplus, Aplus);
-        doublehorner(Cminus, Aminus);
+        doublehorner(Cplus, Aplus, get_NNexp());
+        doublehorner(Cminus, Aminus, get_NNexp());
 
         // Remember rhs = eta, lhs  = xi
 
@@ -575,7 +575,7 @@ void force_clover_fermion_taylor(spinor_field *Xs, spinor_field *Ys, double resi
     suNfc Aplus[4];
     suNfc Aminus[4];
     suNfc *s0, *s1, *s2, *s3;
-    factorialCoef(Coef, get_NN(), get_NNexp());
+    factorialCoef(Coef, get_NNexp());
     // Construct force matrices
     _MASTER_FOR(&glattice, ix) {
         // Create matrix Aplus, Aminus

--- a/LibHR/Utils/factorial.c
+++ b/LibHR/Utils/factorial.c
@@ -10,50 +10,63 @@
 extern "C" {
 #endif
 
-static double *inverse_fact = NULL;
-
-#ifdef WITH_GPU
-__constant__ double inverse_fact_gpu[MAX_FACTORIAL];
+#if MAX_FACTORIAL > 50
+#error "MAX_FACTORIAL cannot be larger than 50. There is probably no reason, to calculate inverse factorials this high."
 #endif
 
-visible static double factorial_core(int N) {
-    double fact = 1.;
-    for (int i = 1; i <= N; ++i) {
-        fact *= i;
-    }
-    return fact;
-}
-
-void init_factorial() {
-    if (inverse_fact == NULL) {
-        _OMP_PRAGMA(single) {
-            inverse_fact = (double *)malloc(sizeof(double) * (MAX_FACTORIAL + 1));
-            for (int i = 0; i <= MAX_FACTORIAL; i++) {
-                inverse_fact[i] = 1. / factorial_core(i);
-            }
-        }
-    }
-
-#ifdef WITH_GPU
-    cudaMemcpyToSymbol(inverse_fact_gpu, inverse_fact, MAX_FACTORIAL * sizeof(double));
-#endif
-}
-
-#ifdef WITH_GPU
-deviceonly double inverse_factorial_gpu(int i) {
-    return inverse_fact_gpu[i];
-}
-#endif
-
-double inverse_factorial(int i) {
-    return inverse_fact[i];
-}
-
-void finalize_factorial() {
-    free(inverse_fact);
-#ifdef WITH_GPU
-    cudaFree(inverse_fact_gpu);
-#endif
+visible double inverse_fact(int i) {
+    static const double inv_fact[51] = { 1.0,
+                                         1.0,
+                                         0.5,
+                                         0.16666666666666666,
+                                         0.041666666666666664,
+                                         0.008333333333333333,
+                                         0.001388888888888889,
+                                         0.0001984126984126984,
+                                         2.48015873015873e-05,
+                                         2.7557319223985893e-06,
+                                         2.755731922398589e-07,
+                                         2.505210838544172e-08,
+                                         2.08767569878681e-09,
+                                         1.6059043836821613e-10,
+                                         1.1470745597729725e-11,
+                                         7.647163731819816e-13,
+                                         4.779477332387385e-14,
+                                         2.8114572543455206e-15,
+                                         1.5619206968586225e-16,
+                                         8.22063524662433e-18,
+                                         4.110317623312165e-19,
+                                         1.9572941063391263e-20,
+                                         8.896791392450574e-22,
+                                         3.8681701706306835e-23,
+                                         1.6117375710961184e-24,
+                                         6.446950284384474e-26,
+                                         2.4795962632247972e-27,
+                                         9.183689863795546e-29,
+                                         3.279889237069838e-30,
+                                         1.1309962886447718e-31,
+                                         3.7699876288159054e-33,
+                                         1.2161250415535181e-34,
+                                         3.800390754854744e-36,
+                                         1.151633562077195e-37,
+                                         3.387157535521162e-39,
+                                         9.67759295863189e-41,
+                                         2.688220266286636e-42,
+                                         7.265460179153071e-44,
+                                         1.911963205040282e-45,
+                                         4.902469756513544e-47,
+                                         1.225617439128386e-48,
+                                         2.9893108271424046e-50,
+                                         7.117406731291439e-52,
+                                         1.6552108677421951e-53,
+                                         3.7618428812322616e-55,
+                                         8.359650847182804e-57,
+                                         1.817315401561479e-58,
+                                         3.866628513960594e-60,
+                                         8.055476070751238e-62,
+                                         1.643974708316579e-63,
+                                         3.2879494166331584e-65 };
+    return inv_fact[i];
 }
 
 #ifdef __cplusplus

--- a/TestProgram/Utils/check_clover_exp.c
+++ b/TestProgram/Utils/check_clover_exp.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
     clover_exp_taylor(test2, exptest2);
 
     lprintf("MAIN", 0, "Evaluating the clover exp via Cayley Hamilton repr\n");
-    clover_exp(test, exptest);
+    clover_exp(test, exptest, get_NN());
 
     lprintf("MAIN", 0, "Comparing the results\n");
 


### PR DESCRIPTION
I changed the structure of the factorial as discussed, so that the calculation of the inverse factorial can be 'visible'. In this PR this adds no new features, however, the inverse factorial is used in other parts of the code that are crucial to be ported to the GPU for porting the HMC. In order to avoid code duplication simply because of the inverse factorial, this implementation change is necessary.

I also needed to reverse the code duplication in the exponential clover utils that was done before because of this issue.