### PR TITLE
No buffer overflowing for very large local lattices

### DIFF
--- a/Include/Core/global.h
+++ b/Include/Core/global.h
@@ -233,6 +233,14 @@ GLB_VAR(int, four_fermion_active, = 0); // whether four fermion interactions are
 #define THREADSIZE 1
 #endif
 
+// Maximum size of messages sent via openmpi
+// You can set this to something very large
+// Sometimes it can be beneficial to cut up
+// messages into smaller messages
+// This is limited to the maximum integer size
+// due to the MPI API
+#define MAX_MSG_SIZE (1 << 30)
+
 #undef GLB_VAR
 
 #endif

--- a/Include/Core/spinor_field.h
+++ b/Include/Core/spinor_field.h
@@ -53,6 +53,7 @@ extern "C" {
 #undef _MPI_FIELD_DATA
 #define _MPI_FIELD_DATA(_type) \
     MPI_Request *comm_req;     \
+    unsigned int nreqs;        \
     _type *sendbuf_ptr;        \
     _type *sendbuf_gpu_ptr;    \
     _type *recvbuf_gpu_ptr;

--- a/Include/Error/error_handling.h
+++ b/Include/Error/error_handling.h
@@ -45,17 +45,18 @@ void register_sighandlers(void);
         *
         * @param call          Function call that should be checked.
         */
-#define CHECK_MPI(call)                                                     \
-    do {                                                                    \
-        const int mpireturn = call;                                         \
-        if (mpireturn != MPI_SUCCESS) {                                     \
-            char message[MPI_MAX_ERROR_STRING];                             \
-            int message_length;                                             \
-            MPI_Error_string(mpireturn, message, &message_length);          \
-            error(1, 1, "Error in: %s:%d, function: %s\n \
-                            Communications call exited with code %d: %s\n", \
-                  __FILE__, __LINE__, __func__, mpireturn, message);        \
-        }                                                                   \
+#define CHECK_MPI(call)                                                                                                      \
+    do {                                                                                                                     \
+        const int mpireturn = call;                                                                                          \
+        if (mpireturn != MPI_SUCCESS) {                                                                                      \
+            char message[MPI_MAX_ERROR_STRING];                                                                              \
+            int message_length;                                                                                              \
+            MPI_Error_string(mpireturn, message, &message_length);                                                           \
+            char msg[500];                                                                                                   \
+            sprintf(msg, "Error in: %s:%d, function: %s\nCommunications call exited with code %d: %s\n", __FILE__, __LINE__, \
+                    __func__, mpireturn, message);                                                                           \
+            error(1, 1, __func__, msg);                                                                                      \
+        }                                                                                                                    \
     } while (0)
 #endif
 

--- a/LibHR/Geometry/TMPL/communications_reduced.c.tmpl
+++ b/LibHR/Geometry/TMPL/communications_reduced.c.tmpl
@@ -63,9 +63,8 @@ _DECLARE(start_sendrecv_reduced_, (_FIELD_TYPE * f)) {
 
 _DECLARE(complete_sendrecv_reduced_, (_FIELD_TYPE * f)) {
 #ifdef WITH_MPI
-    int nreq = 2 * _NUMBER_OF_BUFFERS(f->type, _GEOM_TYPE);
     _F_NAME(release_communications_, _FIELD_TYPE)(f);
-    hr_sendrecv_complete(nreq, f->comm_req);
+    hr_sendrecv_complete(f->nreqs, f->comm_req);
 #endif
 }
 

--- a/LibHR/Geometry/hr_sendrecv.c
+++ b/LibHR/Geometry/hr_sendrecv.c
@@ -25,31 +25,57 @@
 
 #define roundUp(_val, _mod) ((((_val - 1) / (_mod)) + 1) * (_mod))
 
+#define min(a, b) (a > b) ? b : a
+
 void hr_sendrecv_complete(int nreq, MPI_Request *field_reqs) {
     if (nreq > 0) {
         MPI_Status status[nreq];
-        MPI_Waitall(nreq, field_reqs, status);
+        CHECK_MPI(MPI_Waitall(nreq, field_reqs, status));
     }
 }
 
 void hr_sendrecv(void *sendbuffer, void *recvbuffer, geometry_descriptor *type, MPI_Datatype mpi_real_type, int field_dim,
                  int size_of_real, int mpi_chunks_per_site, int nbuffers, MPI_Request *field_reqs) {
     int chars_per_site = mpi_chunks_per_site * size_of_real / sizeof(char);
+    int tag_counter = 0;
 
     _BUFFER_FOR(i, nbuffers) {
         char *recv_buffer = (_GET_RECV_BUFFER((char *)recvbuffer, i, field_dim, type, chars_per_site));
         int recv_proc = type->rbuf_from_proc[i];
         int number_of_sites = roundUp(type->rbuf_len[i], THREADSIZE) / 2;
         int recv_size_in_dbl = field_dim * number_of_sites * mpi_chunks_per_site;
-        MPI_Irecv(recv_buffer, recv_size_in_dbl, mpi_real_type, recv_proc, i, cart_comm, &(field_reqs[2 * i + 1]));
+
+        const int n_messages = (recv_size_in_dbl - 1) / MAX_MSG_SIZE + 1;
+        for (int msg_id = 0; msg_id < n_messages; msg_id++) {
+            char *recv_msg = recv_buffer + msg_id * MAX_MSG_SIZE * size_of_real;
+            int start_of_message = MAX_MSG_SIZE * msg_id;
+            int end_of_message = min(MAX_MSG_SIZE * (msg_id + 1), recv_size_in_dbl);
+            const int msg_size = end_of_message - start_of_message;
+            CHECK_MPI(
+                MPI_Irecv(recv_msg, msg_size, mpi_real_type, recv_proc, tag_counter, cart_comm, &(field_reqs[tag_counter])));
+            tag_counter++;
+        }
     }
+
+    tag_counter = 0;
+    MPI_Barrier(cart_comm);
 
     _BUFFER_FOR(i, nbuffers) {
         char *send_buffer = (_GET_SEND_BUFFER((char *)sendbuffer, i, field_dim, type, chars_per_site));
         int send_proc = type->sbuf_to_proc[i];
         int number_of_sites = roundUp(type->sbuf_len[i], THREADSIZE) / 2;
         int send_size_in_dbl = field_dim * number_of_sites * mpi_chunks_per_site;
-        MPI_Isend(send_buffer, send_size_in_dbl, mpi_real_type, send_proc, i, cart_comm, &(field_reqs[2 * i]));
+
+        const int n_messages = (send_size_in_dbl - 1) / MAX_MSG_SIZE + 1;
+        for (int msg_id = 0; msg_id < n_messages; msg_id++) {
+            char *send_msg = send_buffer + msg_id * MAX_MSG_SIZE * size_of_real;
+            int start_of_message = MAX_MSG_SIZE * msg_id;
+            int end_of_message = min(MAX_MSG_SIZE * (msg_id + 1), send_size_in_dbl);
+            const int msg_size = end_of_message - start_of_message;
+            CHECK_MPI(MPI_Isend(send_msg, msg_size, mpi_real_type, send_proc, tag_counter, cart_comm,
+                                &(field_reqs[2 * tag_counter])));
+            tag_counter++;
+        }
     }
 }
 

--- a/LibHR/Memory/TMPL/field_alloc.c.tmpl
+++ b/LibHR/Memory/TMPL/field_alloc.c.tmpl
@@ -27,6 +27,9 @@
 #if !defined _IS_SPINOR_LIKE
 #error Missing _IS_SPINOR_LIKE in memory.c
 #endif
+#if !defined _REAL
+#error Missing _REAL in memory.c
+#endif
 
 #define _F_ARGS(_name, _args) _FIELD_TYPE *_F_NAME(_name, _FIELD_TYPE) _args
 
@@ -145,14 +148,24 @@ _DECLARE_STATIC(free_mpi_field_data_, (_FIELD_TYPE * f)) {
 _DECLARE_STATIC(allocate_mpi_field_data_, (unsigned int n, _FIELD_TYPE *f, geometry_descriptor *type)) {
 #ifdef WITH_MPI
     if ((_NUMBER_OF_BUFFERS(type, _GEOM_TYPE)) > 0) {
-        int number_of_requests = n * 2 * _NUMBER_OF_BUFFERS(type, _GEOM_TYPE);
+        int number_of_requests = 0;
+        for (int buff_id = 0; buff_id < _NUMBER_OF_BUFFERS(type, _GEOM_TYPE); buff_id++) {
+            int nbuffers_in_request =
+                ((_FIELD_DIM * f->type->rbuf_len[buff_id] * sizeof(_SITE_TYPE) / sizeof(_REAL)) - 1) / MAX_MSG_SIZE + 1;
+            number_of_requests += (nbuffers_in_request - 1) / 2 + 1;
+        }
+        number_of_requests *= n * 2; // As much as there are fields (factor n)
+            // and we need a send and a receive handle each (factor 2)
+        f->nreqs = number_of_requests / n;
         f->comm_req = amalloc(number_of_requests * sizeof(MPI_Request), ALIGN);
         error((f->comm_req) == NULL, 1, __func__, "Could not allocate memory space for field (MPI).\n");
         for (int ix = 0; ix < number_of_requests; ++ix) {
             f->comm_req[ix] = MPI_REQUEST_NULL;
         }
         for (int i = 1; i < n; ++i) {
-            f[i].comm_req = f[i - 1].comm_req + 2 * _NUMBER_OF_BUFFERS(type, _GEOM_TYPE);
+            f[i].comm_req = f[i - 1].comm_req + number_of_requests / n;
+            f[i].nreqs = number_of_requests / n;
+            // f[i].comm_req = f[i - 1].comm_req + 2 * _NUMBER_OF_BUFFERS(type, _GEOM_TYPE);
         }
         for (int i = 0; i < n; ++i) {
             _CALL(allocate_sendbuffer_)(f, i);
@@ -200,3 +213,4 @@ _ALLOCATE {
 #undef _SITE_TYPE
 #undef _FIELD_DIM
 #undef _IS_SPINOR_LIKE
+#undef _REAL

--- a/LibHR/Memory/memory.c
+++ b/LibHR/Memory/memory.c
@@ -11,88 +11,103 @@
 #define _SITE_TYPE suNf_spinor
 #define _FIELD_DIM 1
 #define _IS_SPINOR_LIKE 1
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE spinor_field_flt
 #define _SITE_TYPE suNf_spinor_flt
 #define _FIELD_DIM 1
 #define _IS_SPINOR_LIKE 1
+#define _REAL float
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE scalar_field
 #define _SITE_TYPE double
 #define _FIELD_DIM 1
 #define _IS_SPINOR_LIKE 1
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNg_field
 #define _SITE_TYPE suNg
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNg_field_flt
 #define _SITE_TYPE suNg_flt
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL float
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNf_field
 #define _SITE_TYPE suNf
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNfc_field
 #define _SITE_TYPE suNfc
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNf_field_flt
 #define _SITE_TYPE suNf_flt
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL float
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNg_scalar_field
 #define _SITE_TYPE suNg_vector
 #define _FIELD_DIM 1
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE suNg_av_field
 #define _SITE_TYPE suNg_algebra_vector
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE gtransf
 #define _SITE_TYPE suNg
 #define _FIELD_DIM 1
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE ldl_field
 #define _SITE_TYPE ldl_t
 #define _FIELD_DIM 1
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE clover_term
 #define _SITE_TYPE suNfc
 #define _FIELD_DIM 4
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE clover_force
 #define _SITE_TYPE suNf
 #define _FIELD_DIM 6
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"
 
 #define _FIELD_TYPE staple_field
 #define _SITE_TYPE suNg
 #define _FIELD_DIM 3
 #define _IS_SPINOR_LIKE 0
+#define _REAL double
 #include "TMPL/field_alloc.c.tmpl"

--- a/TestProgram/PureGauge/check_puregauge_5.c
+++ b/TestProgram/PureGauge/check_puregauge_5.c
@@ -7,7 +7,7 @@
 
 #include "libhr.h"
 
-static suNg_field *g;
+static gtransf *g;
 
 static void random_g(void) {
     _MASTER_FOR(&glattice, ix) {


### PR DESCRIPTION
It can happen for rather large local lattices, such as for example 128^2x64^2 that an integer is not enough to capture the size of the buffer in MPI elementary types. We cannot use size_t here, so we have to cut the buffers up and send the pieces one by one. This implementation overflows when size_t is overflowed.