### PR TITLE
Unitarity projection improvement

### DIFF
--- a/Include/Utils/mat_utils.h
+++ b/Include/Utils/mat_utils.h
@@ -13,7 +13,7 @@ extern "C" {
 
 //inv_Cmplx_Ng.c
 #ifndef GAUGE_SON
-visible void ludcmp(hr_complex *a, int *indx, double *d, int N);
+visible void ludcmp(hr_complex *a, int *indx, double *d);
 visible void lubksb(hr_complex *a, int *indx, hr_complex *b, int N);
 visible void inv_Cmplx_Ng(suNg *a);
 #endif

--- a/LibHR/Utils/det_Cmplx_Ng.c
+++ b/LibHR/Utils/det_Cmplx_Ng.c
@@ -38,7 +38,7 @@ visible void det_Cmplx_Ng(hr_complex *res, suNg *a) {
     int i;
     hr_complex tmp;
     b = *a;
-    ludcmp(b.c, indx, &d, NG);
+    ludcmp(b.c, indx, &d);
     *res = d;
     for (i = 0; i < NG; ++i) {
         _complex_mul(tmp, *res, b.c[NG * i + i]);


### PR DESCRIPTION
This change speeds up the GPU kernel execution by a factor of approximately 200 (of course depending on the lattice size), I have tested it on an 48^4 SU(2) with fermions in the fundamental representation.

It seems to be important depending on how often the user chooses to execute this function. 