### PR TITLE
Avoid the program to hang in the queue after certain errors

### DIFF
--- a/LibHR/Error/error.c
+++ b/LibHR/Error/error.c
@@ -1,5 +1,5 @@
 /***************************************************************************\
-* Copyright (c) 2008, Claudio Pica                                          *   
+* Copyright (c) 2008-2024, Claudio Pica, Sofie Martins                      *   
 * All rights reserved.                                                      * 
 \***************************************************************************/
 
@@ -10,9 +10,11 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include "IO/logger.h"
-#include "Geometry/setup.h"
-#include "error.h"
+//#include "Geometry/setup.h"
+//#include "error.h"
+#include "libhr_core.h"
+#include "io.h"
+#include "geometry.h"
 
 /**
  * @brief Print message to error file defined on startup.
@@ -35,6 +37,7 @@ void error(int test, int no, const char *name, const char *text) {
         if (no < 0) {
             exit(0);
         } else {
+            MPI_Abort(MPI_COMM_WORLD, no);
             finalize_process();
             exit(no);
         }


### PR DESCRIPTION
This happens, for example, when the random number state cannot be found. Only a single process loads the random number state while the other processes wait for its completion. However, if the state cannot be found, MPI_finalize() and exit(1) are called. MPI understands this as a regular exiting of this thread, and the program deadlocks. If one calls MPI_Abort() before MPI_finalize(), MPI knows that a fatal error has occurred and also terminates the other processes.

We need this because if people do not realise fast enough that the program is stuck in the queue, they will continue to use up their allocations without doing anything.