### PR TITLE
Measurements

### DIFF
--- a/Disconnected/compute_loops.c
+++ b/Disconnected/compute_loops.c
@@ -105,7 +105,6 @@ int main(int argc, char *argv[]) {
         }
 
         lprintf("MAIN", 0, "Configuration from %s\n", cnfg_filename);
-        /* NESSUN CHECK SULLA CONSISTENZA CON I PARAMETRI DEFINITI !!! */
         read_gauge_field(cnfg_filename);
         represent_gauge_field();
 
@@ -121,20 +120,11 @@ int main(int argc, char *argv[]) {
 
     if (list != NULL) { fclose(list); }
 
-    finalize_process();
-
-    free_BCs();
-
-    free_suNg_field(u_gauge);
-#ifdef ALLOCATE_REPR_GAUGE_FIELD
-    free_suNf_field(u_gauge_f);
-#endif
+    double elapsed_sec = timer_lap(&clock) * 1.e-6; //time in seconds
+    lprintf("TIMING", 0, "Inversions and contractions for configuration  [%s] done [%lf sec]\n", cnfg_filename, elapsed_sec);
 
     /* close communications */
     finalize_process();
-
-    double elapsed_sec = timer_lap(&clock) * 1.e-6; //time in seconds
-    lprintf("TIMING", 0, "Inversions and contractions for configuration  [%s] done [%lf sec]\n", cnfg_filename, elapsed_sec);
 
     return 0;
 }

--- a/Include/Geometry/geometry_indexing.h
+++ b/Include/Geometry/geometry_indexing.h
@@ -16,4 +16,10 @@
 #define iup(site, dir) iup[(site) * 4 + (dir)]
 #define idn(site, dir) idn[(site) * 4 + (dir)]
 
+#ifdef WITH_GPU
+#define _PTR(_field) (_field)->gpu_ptr
+#else
+#define _PTR(_field) (_field)->ptr
+#endif
+
 #endif

--- a/LibHR/Observables/calc_prop.c
+++ b/LibHR/Observables/calc_prop.c
@@ -189,6 +189,9 @@ static void calc_propagator_eo_core(spinor_field *psi, spinor_field *eta, int so
 #else
     spinor_field eta_mask;
     eta_mask.type = &glat_even;
+#ifdef WITH_GPU
+    eta_mask.gpu_ptr = eta->gpu_ptr;
+#endif
     eta_mask.ptr = eta->ptr;
     copy_spinor_field(tmp_even, &eta_mask);
 #endif
@@ -228,6 +231,9 @@ static void calc_propagator_eo_core(spinor_field *psi, spinor_field *eta, int so
         qprop_mask.type = &glat_even;
         mul_spinor_field(&qprop_mask, (4. + mass[i]), &resd_even[i]);
         qprop_mask.type = &glat_odd;
+#ifdef WITH_GPU
+        qprop_mask.gpu_ptr = psi[i].gpu_ptr + glat_odd.master_shift;
+#endif
         qprop_mask.ptr = psi[i].ptr + glat_odd.master_shift;
         zero_spinor_field(&qprop_mask);
         Dphi_(&qprop_mask, &resd_even[i]);
@@ -258,10 +264,16 @@ static void calc_propagator_core(spinor_field *psi, spinor_field *eta, int solve
    */
     qprop_mask_eta = *eta;
     qprop_mask_eta.type = &glat_odd;
+#ifdef WITH_GPU
+    qprop_mask_eta.gpu_ptr = eta->gpu_ptr + glat_odd.master_shift;
+#endif
     qprop_mask_eta.ptr = eta->ptr + glat_odd.master_shift;
     mul_spinor_field(tmp_odd, (1. / (4. + mass[0])), &qprop_mask_eta);
     Dphi_(tmp_even, tmp_odd);
     qprop_mask_eta.type = &glat_even;
+#ifdef WITH_GPU
+    qprop_mask_eta.gpu_ptr = eta->gpu_ptr;
+#endif
     qprop_mask_eta.ptr = eta->ptr;
     sub_spinor_field(tmp_even, &qprop_mask_eta, tmp_even);
 #ifdef GAUSSIAN_NOISE
@@ -320,6 +332,9 @@ static void calc_propagator_core(spinor_field *psi, spinor_field *eta, int solve
     mul_spinor_field(&qprop_mask_psi, (4. + mass[0]), resd_even);
 
     qprop_mask_psi.type = &glat_odd;
+#ifdef WITH_GPU
+    qprop_mask_psi.gpu_ptr = psi->gpu_ptr + glat_odd.master_shift;
+#endif
     qprop_mask_psi.ptr = psi->ptr + glat_odd.master_shift;
     Dphi_(&qprop_mask_psi, resd_even);
 
@@ -366,6 +381,9 @@ static void calc_propagator_clover(spinor_field *dptr, spinor_field *sptr) {
     dptr_e = *dptr;
     dptr_e.type = &glat_even;
     dptr_o = *dptr;
+#ifdef WITH_GPU
+    dptr_o.gpu_ptr += glat_odd.master_shift;
+#endif
     dptr_o.ptr += glat_odd.master_shift;
     dptr_o.type = &glat_odd;
 
@@ -374,6 +392,9 @@ static void calc_propagator_clover(spinor_field *dptr, spinor_field *sptr) {
     sptr_e = *stmp;
     sptr_e.type = &glat_even;
     sptr_o = *stmp;
+#ifdef WITH_GPU
+    sptr_o.gpu_ptr += glat_odd.master_shift;
+#endif
     sptr_o.ptr += glat_odd.master_shift;
     sptr_o.type = &glat_odd;
 
@@ -549,12 +570,18 @@ static void calc_propagator_eo_tw_core(spinor_field *psi, spinor_field *eta, int
 
     qprop_mask_eta = *eta;
     qprop_mask_eta.type = &glat_odd;
+#ifdef WITH_GPU
+    qprop_mask_eta.gpu_ptr = eta->gpu_ptr + glat_odd.master_shift;
+#endif
     qprop_mask_eta.ptr = eta->ptr + glat_odd.master_shift;
 
     Dxx_tw_inv(mass[0], tw_mass, tmp_odd, &qprop_mask_eta, DIRECT);
 
     Dphi_(tmp_even, tmp_odd);
     qprop_mask_eta.type = &glat_even;
+#ifdef WITH_GPU
+    qprop_mask_eta.gpu_ptr = eta->gpu_ptr;
+#endif
     qprop_mask_eta.ptr = eta->ptr;
 
     sub_assign_spinor_field(tmp_even, &qprop_mask_eta);
@@ -596,18 +623,30 @@ static void calc_propagator_eo_tw_core(spinor_field *psi, spinor_field *eta, int
     mul_spinor_field(&qprop_mask_psi, -((4. + mass[0]) * (4. + mass[0]) + tw_mass * tw_mass), resd_even);
 
     qprop_mask_psi.type = &glat_odd;
+#ifdef WITH_GPU
+    qprop_mask_psi.gpu_ptr = psi->gpu_ptr + glat_odd.master_shift;
+#endif
     qprop_mask_psi.ptr = psi->ptr + glat_odd.master_shift;
     qprop_mask_eta.type = &glat_odd;
+#ifdef WITH_GPU
+    qprop_mask_eta.gpu_ptr = eta->gpu_ptr + glat_odd.master_shift;
+#endif
     qprop_mask_eta.ptr = eta->ptr + glat_odd.master_shift;
 
     Dxx_tw_inv(mass[0], tw_mass, &qprop_mask_psi, &qprop_mask_eta, DIRECT);
 
     qprop_mask_psi.type = &glat_even;
+#ifdef WITH_GPU
+    qprop_mask_psi.gpu_ptr = psi->gpu_ptr;
+#endif
     qprop_mask_psi.ptr = psi->ptr;
     Dphi_(tmp_odd, &qprop_mask_psi);
     Dxx_tw_inv(mass[0], tw_mass, tmp_odd, tmp_odd, DIRECT);
 
     qprop_mask_psi.type = &glat_odd;
+#ifdef WITH_GPU
+    qprop_mask_psi.gpu_ptr = psi->gpu_ptr + glat_odd.master_shift;
+#endif
     qprop_mask_psi.ptr = psi->ptr + glat_odd.master_shift;
 
     sub_assign_spinor_field(&qprop_mask_psi, tmp_odd);

--- a/LibHR/Observables/loop_tools.c
+++ b/LibHR/Observables/loop_tools.c
@@ -263,11 +263,17 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
     if (source_type == 0) {
         source = alloc_spinor_field(1, &glattice);
         prop = alloc_spinor_field(1, &glattice);
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(prop);
+#endif
         zero_spinor_field(prop);
     } else {
         source = alloc_spinor_field(4, &glattice);
         prop = alloc_spinor_field(4, &glattice);
         for (int i = 0; i < 4; i++) {
+#ifdef WITH_GPU
+            zero_spinor_field_cpu(prop + i);
+#endif
             zero_spinor_field(prop + i);
         }
     }
@@ -300,6 +306,9 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
     if (source_type == 1) {
         u_gauge_old = alloc_suNg_field(&glattice);
         copy_suNg_field(u_gauge_old, u_gauge);
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(prop);
+#endif
         zero_spinor_field(prop);
         //Fix the Gauge
         double act = gaugefix(0, //= 0, 1, 2, 3 for Coulomb guage else Landau
@@ -324,7 +333,6 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
 #ifdef WITH_GPU
             copy_from_gpu(prop);
 #endif
-
             lprintf("CORR", 0, "Start to perform the contractions ... \n");
             measure_bilinear_loops_spinorfield(prop, source, k, n_mom, swc, ret);
             lprintf("CORR", 0, "Contraction done\n");
@@ -340,6 +348,11 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
                     calc_propagator(prop, source, 4); //4 for spin dilution
                     create_point_source(source, tau, l); //to get the contraction right
                     //measure_mesons(discon_correlators, prop, source, 1, 0);
+#ifdef WITH_GPU
+                    for (int beta = 0; beta < 4; beta++) {
+                        copy_from_gpu(prop + beta);
+                    }
+#endif
                     measure_bilinear_loops_4spinorfield(prop, source, k, tau, l, -1, swc, ret);
                 }
             }
@@ -353,6 +366,11 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
             for (tau = 0; tau < GLB_T; ++tau) {
                 create_diluted_source_equal_atau(source, tau);
                 calc_propagator(prop, source, 4); //4 for spin dilution
+#ifdef WITH_GPU
+                for (int beta = 0; beta < 4; beta++) {
+                    copy_from_gpu(prop + beta);
+                }
+#endif
                 measure_bilinear_loops_4spinorfield(prop, source, k, tau, -1, -1, swc, ret);
             }
 
@@ -362,8 +380,12 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
             for (tau = 0; tau < GLB_T; ++tau) {
                 for (col = 0; col < NF; ++col) {
                     create_diluted_source_equal_atau_col(source, tau, col);
-
                     calc_propagator(prop, source, 4); //4 for spin dilution
+#ifdef WITH_GPU
+                    for (int beta = 0; beta < 4; beta++) {
+                        copy_from_gpu(prop + beta);
+                    }
+#endif
                     measure_bilinear_loops_4spinorfield(prop, source, k, tau, col, -1, swc, ret);
                 }
             }
@@ -377,6 +399,11 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
                         create_diluted_source_equal_atau_col(source, tau, col);
                         zero_even_or_odd_site_spinorfield(source, n_spinor, eo);
                         calc_propagator(prop, source, 4); //4 for spin dilution
+#ifdef WITH_GPU
+                        for (int beta = 0; beta < 4; beta++) {
+                            copy_from_gpu(prop + beta);
+                        }
+#endif
                         measure_bilinear_loops_4spinorfield(prop, source, k, tau, col, eo, swc, ret);
                     }
                 }
@@ -390,6 +417,11 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
                     create_noise_source_equal_col_dil(source, col);
                     zero_even_or_odd_site_spinorfield(source, n_spinor, eo); //set even or odd site to zero
                     calc_propagator(prop, source, 4); //4 for spin dilution
+#ifdef WITH_GPU
+                    for (int beta = 0; beta < 4; beta++) {
+                        copy_from_gpu(prop + beta);
+                    }
+#endif
                     measure_bilinear_loops_4spinorfield(prop, source, k, -1, col, eo, swc, ret);
                 }
             }

--- a/LibHR/Observables/loop_tools.c
+++ b/LibHR/Observables/loop_tools.c
@@ -321,6 +321,9 @@ void measure_loops(double *m, int nhits, int conf_num, double precision, int sou
         {
             create_z2_volume_source(source);
             calc_propagator(prop, source, 1); // No dilution
+#ifdef WITH_GPU
+            copy_from_gpu(prop);
+#endif
 
             lprintf("CORR", 0, "Start to perform the contractions ... \n");
             measure_bilinear_loops_spinorfield(prop, source, k, n_mom, swc, ret);

--- a/LibHR/Observables/meson_measurements.c
+++ b/LibHR/Observables/meson_measurements.c
@@ -103,7 +103,6 @@ void measure_spectrum_pt(int tau, int nm, double *m, int n_mom, int conf_num, do
             copy_from_gpu(prop + 4 * k + beta);
         }
 #endif
-        if (k == 0) { printf("prop no 1 @ idx 5: %0.15e\n", creal((*_FIELD_AT(prop, 5)).c[0].c[0])); }
         if (n_mom > 1) {
             measure_point_mesons_momenta(meson_correlators, prop + 4 * k, source, nm, tau, n_mom);
         } else {

--- a/LibHR/Observables/meson_measurements.c
+++ b/LibHR/Observables/meson_measurements.c
@@ -327,6 +327,9 @@ void measure_spectrum_semwall(int nm, double *m, int nhits, int conf_num, double
         lprintf("MAIN", 0, "data_storage_element allocated !\n");
     }
     for (int i = 0; i < 4 * nm; i++) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(prop + i);
+#endif
         zero_spinor_field(prop + i);
     }
 

--- a/LibHR/Observables/pta_qprop.c
+++ b/LibHR/Observables/pta_qprop.c
@@ -81,11 +81,17 @@ void pta_qprop_QMR_eo(int g0[4], spinor_field **pta_qprop, int nm, double *mass,
 
     /* noisy background */
     gaussian_spinor_field(in);
+#ifdef WITH_GPU
+    copy_from_gpu(in);
+#endif
     if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
         for (source = 0; source < NF * 4 * 2; ++source) {
             *((double *)_FIELD_AT(in, x0) + source) = 0.; /* zero in source */
         }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(in);
+#endif
     norm = sqrt(sqnorm_spinor_field(in));
     mul_spinor_field(in, 1. / norm, in);
 
@@ -113,11 +119,18 @@ void pta_qprop_QMR_eo(int g0[4], spinor_field **pta_qprop, int nm, double *mass,
     g5_assign_spinor_field(in);
 
     /* now loop over sources */
+
     for (source = 0; source < 4 * NF; ++source) {
         /* put in source on an EVEN site */
+#ifdef WITH_GPU
+        copy_from_gpu(in);
+#endif
         if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
             *((double *)_FIELD_AT(in, x0) + 2 * source) = 1.;
         }
+#ifdef WITH_GPU
+        copy_to_gpu(in);
+#endif
         g5_assign_spinor_field(in);
 
         for (i = 0; i < QMR_par.n; ++i) {
@@ -152,7 +165,7 @@ void pta_qprop_QMR_eo(int g0[4], spinor_field **pta_qprop, int nm, double *mass,
 
             mul_spinor_field(&qprop_mask, (4. + mass[i]), &resd[i]);
             qprop_mask.type = &glat_odd;
-            qprop_mask.ptr = pta_qprop[i][source].ptr + glat_odd.master_shift;
+            _PTR(&qprop_mask) = _PTR(&(pta_qprop[i][source])) + glat_odd.master_shift;
 
             Dphi_(&qprop_mask, &resd[i]);
             minus_spinor_field(&qprop_mask, &qprop_mask);
@@ -174,9 +187,15 @@ void pta_qprop_QMR_eo(int g0[4], spinor_field **pta_qprop, int nm, double *mass,
 
         /* remove source */
         g5_assign_spinor_field(in);
+#ifdef WITH_GPU
+        copy_from_gpu(in);
+#endif
         if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
             *((double *)_FIELD_AT(in, x0) + 2 * source) = 0.;
         }
+#ifdef WITH_GPU
+        copy_to_gpu(in);
+#endif
     }
 
     lprintf("PROPAGATOR", 10, "QMR_eo MVM = %d\n", cgiter);
@@ -243,11 +262,17 @@ void pta_qprop_QMR(int g0[4], spinor_field **pta_qprop, int nm, double *mass, do
 
     /* noisy background */
     gaussian_spinor_field(in);
+#ifdef WITH_GPU
+    copy_from_gpu(in);
+#endif
     if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
         for (source = 0; source < NF * 4 * 2; ++source) {
             *((double *)_FIELD_AT(in, x0) + source) = 0.; /* zero in source */
         }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(in);
+#endif
     norm = sqrt(sqnorm_spinor_field(in));
     mul_spinor_field(in, 1. / norm, in);
 
@@ -257,11 +282,18 @@ void pta_qprop_QMR(int g0[4], spinor_field **pta_qprop, int nm, double *mass, do
     g5_assign_spinor_field(in);
 
     /* now loop over sources */
+
     for (source = 0; source < 4 * NF; ++source) {
+#ifdef WITH_GPU
+        copy_from_gpu(in);
+#endif
         /* put in source */
         if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
             *((double *)_FIELD_AT(in, x0) + 2 * source) = 1.;
         }
+#ifdef WITH_GPU
+        copy_to_gpu(in);
+#endif
         g5_assign_spinor_field(in);
 
         cgiter += g5QMR_mshift(&QMR_par, &D_pta, in, resd);
@@ -296,9 +328,15 @@ void pta_qprop_QMR(int g0[4], spinor_field **pta_qprop, int nm, double *mass, do
 
         /* remove source */
         g5_assign_spinor_field(in);
+#ifdef WITH_GPU
+        copy_from_gpu(in);
+#endif
         if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
             *((double *)_FIELD_AT(in, x0) + 2 * source) = 0.;
         }
+#ifdef WITH_GPU
+        copy_to_gpu(in);
+#endif
     }
 
     lprintf("PROPAGATOR", 10, "QMR MVM = %d\n", cgiter);
@@ -344,10 +382,16 @@ void pta_qprop_MINRES(int g0[4], spinor_field **pta_qprop, int nm, double *mass,
     cgiter = 0;
 
     for (source = 0; source < 4 * NF; ++source) {
+#ifdef WITH_GPU
+        copy_from_gpu(in);
+#endif
         /* put in source */
         if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
             *((double *)_FIELD_AT(in, x0) + 2 * source) = 1.;
         }
+#ifdef WITH_GPU
+        copy_to_gpu(in);
+#endif
 
 #ifndef NDEBUG
         norm = sqnorm_spinor_field(in);
@@ -365,10 +409,16 @@ void pta_qprop_MINRES(int g0[4], spinor_field **pta_qprop, int nm, double *mass,
             cgiter += MINRES(&MINRESpar, &H_pta, in, &pta_qprop[i][source], &pta_qprop[i - 1][source]);
         }
 
+#ifdef WITH_GPU
+        copy_from_gpu(in);
+#endif
         /* remove source */
         if (COORD[0] == C0[0] && COORD[1] == C0[1] && COORD[2] == C0[2] && COORD[3] == C0[3]) {
             *((double *)_FIELD_AT(in, x0) + 2 * source) = 0.;
         }
+#ifdef WITH_GPU
+        copy_to_gpu(in);
+#endif
     }
 
     lprintf("PROPAGATOR", 10, "MINRES MVM = %d", cgiter);

--- a/LibHR/Observables/sources.c
+++ b/LibHR/Observables/sources.c
@@ -71,6 +71,9 @@ static int random_tau() {
 void create_point_source(spinor_field *source, int tau, int color) {
     int beta, ix;
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
     if (COORD[0] == tau / T && COORD[1] == 0 && COORD[2] == 0 && COORD[3] == 0) {
@@ -92,6 +95,9 @@ void create_full_point_source(spinor_field *source, int tau) {
     int col, beta, idx, ix;
 
     for (beta = 0; beta < 4 * NF; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
 
@@ -116,6 +122,9 @@ void create_full_point_source(spinor_field *source, int tau) {
 void create_point_source_loc(spinor_field *source, int t, int x, int y, int z, int color) {
     int beta, ix;
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
     if (zerocoord[0] <= t && t < zerocoord[0] + T && zerocoord[1] <= x && x < zerocoord[1] + X && zerocoord[2] <= y &&
@@ -183,6 +192,9 @@ void create_diluted_source_equal_atau_eo(spinor_field *source, int tau) {
     int i;
     // int tau = random_tau();
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
     if (zerocoord[0] <= tau && tau < zerocoord[0] + T) { // Check that tau is in this thread.
@@ -212,6 +224,9 @@ int create_diluted_source_equal(spinor_field *source) {
     int i;
     int tau = random_tau();
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
 
@@ -245,6 +260,9 @@ void create_diluted_source_equal_atau(spinor_field *source, int tau) {
     suNf_vector *v1, *v2;
     int i;
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
 
@@ -302,6 +320,9 @@ void create_noise_source_equal_eo(spinor_field *source) {
     int i;
 
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
 
@@ -338,6 +359,9 @@ void create_noise_source_equal_oe(spinor_field *source) {
     int i;
 
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
 
@@ -374,6 +398,9 @@ void create_diluted_source_equal_atau_col(spinor_field *source, int tau, int col
     hr_complex *v1;
     int i;
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
     if (zerocoord[0] <= tau && tau < zerocoord[0] + T) { // Check that tau is in this thread.
@@ -404,6 +431,9 @@ void create_noise_source_equal_col_dil(spinor_field *source, int col) {
     int i;
 
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
 
@@ -436,6 +466,9 @@ void create_gauge_fixed_wall_source(spinor_field *source, int tau, int color) {
     int beta;
 
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
 
@@ -467,6 +500,9 @@ void create_sequential_source(spinor_field *source, int tf, spinor_field *prop) 
     suNf_propagator sp0, sp1;
 
     for (beta = 0; beta < 4 * NF; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
 
@@ -509,6 +545,9 @@ void create_sequential_source_stoch(spinor_field *source, int tf, spinor_field *
     suNf_propagator sp0, sp1;
 
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
 
@@ -570,6 +609,9 @@ void create_gauge_fixed_momentum_source(spinor_field *source, int pt, int px, in
     double pdotx;
 
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
     lprintf("Source", 0, "mom = (%d,%d,%d,%d)", pt, px, py, pz);
@@ -606,6 +648,9 @@ void add_momentum(spinor_field *out, spinor_field *in, int px, int py, int pz) {
     double pdotx;
 
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&out[beta]);
+#endif
         zero_spinor_field(&out[beta]);
     }
     lprintf("Adding momentum to the source", 0, "mom = (%d,%d,%d)", px, py, pz);
@@ -647,6 +692,9 @@ void create_diluted_volume_source(spinor_field *source, int parity_component, in
     int beta, b;
 
     for (beta = 0; beta < 4; ++beta) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[beta]);
+#endif
         zero_spinor_field(&source[beta]);
     }
 

--- a/LibHR/Observables/sources.c
+++ b/LibHR/Observables/sources.c
@@ -155,6 +155,9 @@ int create_diluted_source_equal_eo(spinor_field *source) {
     int i;
     int tau = random_tau();
     for (i = 0; i < 4; ++i) {
+#ifdef WITH_GPU
+        zero_spinor_field_cpu(&source[i]);
+#endif
         zero_spinor_field(&source[i]);
     }
 

--- a/LibHR/Update/Dphi.c
+++ b/LibHR/Update/Dphi.c
@@ -20,12 +20,6 @@
 #include "memory.h"
 #include "utils.h"
 
-#ifdef WITH_GPU
-#define _PTR(_field) _field->gpu_ptr
-#else
-#define _PTR(_field) _field->ptr
-#endif
-
 #ifdef BC_T_SF_ROTATED
 #include "update.h"
 extern rhmc_par _update_par; /* Update/update_rhmc.c */

--- a/LibHR/Utils/gaugefix.c
+++ b/LibHR/Utils/gaugefix.c
@@ -24,6 +24,7 @@ void unit_gauge(suNg_field *gauge) {
     }
 #ifdef WITH_GPU
     copy_to_gpu(gauge);
+    gauge->comm_type = ALL_COMMS;
 #endif
     start_sendrecv_suNg_field(gauge);
     complete_sendrecv_suNg_field(gauge);
@@ -59,6 +60,10 @@ static void gUgmu(suNg_field *gauge) {
             }
         }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(gauge);
+    gauge->comm_type = ALL_COMMS;
+#endif
     start_sendrecv_suNg_field(gauge);
     complete_sendrecv_suNg_field(gauge);
 }
@@ -79,13 +84,22 @@ void random_gauge_transform(suNg_field *gauge) {
             }
         }
     }
-
+#ifdef WITH_GPU
+    copy_to_gpu(gauge);
+    gauge->comm_type = ALL_COMMS;
+#endif
     start_sendrecv_suNg_field(g);
     complete_sendrecv_suNg_field(g);
     gUgmu(gauge);
 }
 
 double calc_plaq(suNg_field *V) {
+#ifdef WITH_GPU
+    copy_from_gpu(V);
+    V->comm_type = CPU_COMM;
+    start_sendrecv_suNg_field(V);
+    complete_sendrecv_suNg_field(V);
+#endif
     int mu, nu;
     int iy, iz;
     suNg *v1, *v2, *v3, *v4, w1, w2, w3;
@@ -124,6 +138,10 @@ double calc_plaq(suNg_field *V) {
         }
     }
 
+#ifdef WITH_GPU
+    V->comm_type = GPU_COMM;
+#endif
+
     global_sum(&E, 1);
     return E / (6. * NG) / GLB_VOLUME;
 }
@@ -145,6 +163,9 @@ void reunit(suNg_field *fixed_gauge) {
             }
         }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(fixed_gauge);
+#endif
     start_sendrecv_suNg_field(fixed_gauge);
     complete_sendrecv_suNg_field(fixed_gauge);
 }
@@ -323,6 +344,12 @@ double gaugefixstep(int fix_dir, double overrelax, suNg_field *fixed_gauge) {
 
 double gaugefix(int fix_dir, double overrelax, int max_it, double fix_tol, suNg_field *fixed_gauge) {
     lprintf("GAUGE FIXING", 30, "Reunitarizing every %d steps.\n", REUNIT);
+#ifdef WITH_GPU
+    copy_from_gpu(fixed_gauge);
+    fixed_gauge->comm_type = ALL_COMMS;
+    start_sendrecv_suNg_field(fixed_gauge);
+    complete_sendrecv_suNg_field(fixed_gauge);
+#endif
     int it;
     double new_act, old_act = 0., diff_act;
     init_g();
@@ -351,5 +378,12 @@ double gaugefix(int fix_dir, double overrelax, int max_it, double fix_tol, suNg_
 
     new_act = gaugefix_action(fix_dir, fixed_gauge);
     free_g();
+
+#ifdef WITH_GPU
+    copy_to_gpu(fixed_gauge);
+    fixed_gauge->comm_type = GPU_COMM;
+#endif
+    start_sendrecv_suNg_field(fixed_gauge);
+    complete_sendrecv_suNg_field(fixed_gauge);
     return new_act;
 }

--- a/LibHR/Utils/gaugefix.c
+++ b/LibHR/Utils/gaugefix.c
@@ -197,6 +197,10 @@ double gaugefix_action(int fix_dir, suNg_field *gauge) {
     for (mu = 0; mu < 4; mu++) {
         if (mu != fix_dir) { ndir++; }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(gauge);
+    gauge->comm_type = ALL_COMMS;
+#endif
     global_sum(&action, 1);
     action *= 1. / (NG * ndir * GLB_T * GLB_X * GLB_Y * GLB_Z);
     return action;
@@ -325,6 +329,10 @@ void su2_hit(int fix_dir, int parity, double overrelax, suNg_field *fixed_gauge,
             }
         }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(g);
+    g->comm_type = ALL_COMMS;
+#endif
     start_sendrecv_suNg_field(g);
     complete_sendrecv_suNg_field(g);
 }

--- a/LibHR/Utils/gaugefix.c
+++ b/LibHR/Utils/gaugefix.c
@@ -22,6 +22,9 @@ void unit_gauge(suNg_field *gauge) {
             }
         }
     }
+#ifdef WITH_GPU
+    copy_to_gpu(gauge);
+#endif
     start_sendrecv_suNg_field(gauge);
     complete_sendrecv_suNg_field(gauge);
 }

--- a/LibHR/Utils/shift_fields.c
+++ b/LibHR/Utils/shift_fields.c
@@ -25,9 +25,9 @@ void shift_fields(int *shift, spinor_field *sin, suNg_field *uin, spinor_field *
 
     int total_shift = shift[0] + shift[1] + shift[2] + shift[3];
     if (total_shift == 0) {
-        if (sin != NULL) { copy_spinor_field(sout, sin); }
+        if (sin != NULL) { copy_spinor_field_cpu(sout, sin); }
 
-        if (uin != NULL) { copy_suNg_field(uout, uin); }
+        if (uin != NULL) { copy_suNg_field_cpu(uout, uin); }
     }
 
     if (sin != NULL) {
@@ -58,8 +58,8 @@ void shift_fields(int *shift, spinor_field *sin, suNg_field *uin, spinor_field *
     if (sin != NULL) {
         sbuf[0] = alloc_spinor_field(1, &glattice);
         sbuf[1] = alloc_spinor_field(1, &glattice);
-        zero_spinor_field(sbuf[0]);
-        zero_spinor_field(sbuf[1]);
+        zero_spinor_field_cpu(sbuf[0]);
+        zero_spinor_field_cpu(sbuf[1]);
     } else {
         sbuf[0] = sbuf[1] = NULL;
     }

--- a/TestProgram/Disconnected/check_disc_2.c
+++ b/TestProgram/Disconnected/check_disc_2.c
@@ -168,6 +168,7 @@ int main(int argc, char *argv[]) {
     double abs_tol = 5e-2;
     double rel_tol_scalar_loop = 1e-3;
     struct timeval start, end, etime;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     hr_complex g[16][4][4];
     hr_complex tmp[4][4];
@@ -205,11 +206,8 @@ int main(int argc, char *argv[]) {
 
     /* setup process id and communications */
     setup_process(&argc, &argv);
-
     setup_gauge_fields();
-
     read_input(mes_ip.read, get_input_filename());
-
     strcpy(pame, mes_ip.mstring);
     mass = atof(strtok(pame, ";"));
 
@@ -217,12 +215,12 @@ int main(int argc, char *argv[]) {
     lprintf("MAIN", 0, "disc:nhits = %i\n", mes_ip.nhits);
     lprintf("MAIN", 0, "Inverter precision = %e\n", mes_ip.precision);
     lprintf("MAIN", 0, "Number of momenta = %d\n", mes_ip.n_mom);
+
 #if defined(WITH_CLOVER) || defined(WITH_EXPCLOVER)
     set_csw(&mes_ip.csw);
 #endif
 
     gettimeofday(&start, 0);
-
     unit_u(u_gauge);
     represent_gauge_field();
 #ifdef REPR_FUNDAMENTAL
@@ -230,13 +228,9 @@ int main(int argc, char *argv[]) {
 #endif
 
     lprintf("MAIN", 0, "source type is fixed to 2:Time and spin dilution \n");
-
     lprintf("MAIN", 0, "Measuring D(t) =  sum_x psibar(x) Gamma psi(x)\n");
-
     lprintf("MAIN", 0, "Zerocoord{%d,%d,%d,%d}\n", zerocoord[0], zerocoord[1], zerocoord[2], zerocoord[3]);
-
     error(!(GLB_X == GLB_Y && GLB_X == GLB_Z), 1, "main", "This test works only for GLB_X=GLB_Y=GLB_Z");
-
     lprintf("CORR", 0, "Number of noise vector : nhits = %i \n", mes_ip.nhits);
     measure_loops(&mass, mes_ip.nhits, 0, mes_ip.precision, source_type, mes_ip.n_mom, STORE, &out_corr);
 

--- a/TestProgram/Disconnected/check_disc_3.c
+++ b/TestProgram/Disconnected/check_disc_3.c
@@ -167,6 +167,7 @@ int main(int argc, char *argv[]) {
     double abs_tol = 1.5e-1;
     double rel_tol_scalar_loop = 1e-3;
     struct timeval start, end, etime;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     hr_complex g[16][4][4];
     hr_complex tmp[4][4];

--- a/TestProgram/Disconnected/check_disc_4.c
+++ b/TestProgram/Disconnected/check_disc_4.c
@@ -167,6 +167,7 @@ int main(int argc, char *argv[]) {
     double abs_tol = 1e-1;
     double rel_tol_scalar_loop = 1e-3;
     struct timeval start, end, etime;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     hr_complex g[16][4][4];
     hr_complex tmp[4][4];

--- a/TestProgram/Disconnected/check_disc_5.c
+++ b/TestProgram/Disconnected/check_disc_5.c
@@ -184,6 +184,7 @@ int main(int argc, char *argv[]) {
     double abs_tol = 1e-1;
     double rel_tol_scalar_loop = 5.e-3;
     struct timeval start, end, etime;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     hr_complex g[16][4][4];
     hr_complex tmp[4][4];

--- a/TestProgram/GaugeFix/check_gaugefix.c
+++ b/TestProgram/GaugeFix/check_gaugefix.c
@@ -8,6 +8,16 @@
 #include "libhr.h"
 
 static double calc_plaq_diff(suNg_field *V, suNg_field *W) {
+#ifdef WITH_GPU
+    copy_from_gpu(V);
+    V->comm_type = CPU_COMM;
+    start_sendrecv_suNg_field(V);
+    complete_sendrecv_suNg_field(V);
+    copy_from_gpu(W);
+    W->comm_type = CPU_COMM;
+    start_sendrecv_suNg_field(W);
+    complete_sendrecv_suNg_field(W);
+#endif
     int mu, nu;
     int iy, iz;
     suNg *v1, *v2, *v3, *v4, w1, w2, w3;
@@ -58,6 +68,11 @@ static double calc_plaq_diff(suNg_field *V, suNg_field *W) {
         }
     }
 
+#ifdef WITH_GPU
+    V->comm_type = GPU_COMM;
+    W->comm_type = GPU_COMM;
+#endif
+
     global_sum(&E, 1);
     return E / (6. * NG) / GLB_VOLUME;
 }
@@ -66,11 +81,29 @@ static void random_g(gtransf *g) {
     _MASTER_FOR(g->type, ix) {
         random_suNg(_FIELD_AT(g, ix));
     }
+#ifdef WITH_GPU
+    copy_to_gpu(g);
+#endif
 }
 
 static void transform_u(suNg_field *out, suNg_field *in, gtransf *g) {
     int iy, mu;
     suNg v;
+
+#ifdef WITH_GPU
+    copy_from_gpu(g);
+    g->comm_type = CPU_COMM;
+    start_sendrecv_gtransf(g);
+    complete_sendrecv_gtransf(g);
+    copy_from_gpu(in);
+    in->comm_type = CPU_COMM;
+    start_sendrecv_suNg_field(in);
+    complete_sendrecv_suNg_field(in);
+    copy_from_gpu(out);
+    out->comm_type = CPU_COMM;
+    start_sendrecv_suNg_field(out);
+    complete_sendrecv_suNg_field(out);
+#endif
 
     _MASTER_FOR(&glattice, ix) {
         for (mu = 0; mu < 4; mu++) {
@@ -79,6 +112,21 @@ static void transform_u(suNg_field *out, suNg_field *in, gtransf *g) {
             _suNg_times_suNg(*_4FIELD_AT(out, ix, mu), *_FIELD_AT(g, ix), v);
         }
     }
+
+#ifdef WITH_GPU
+    copy_to_gpu(g);
+    g->comm_type = GPU_COMM;
+    start_sendrecv_gtransf(g);
+    complete_sendrecv_gtransf(g);
+    copy_to_gpu(in);
+    in->comm_type = GPU_COMM;
+    start_sendrecv_suNg_field(in);
+    complete_sendrecv_suNg_field(in);
+    copy_to_gpu(out);
+    out->comm_type = GPU_COMM;
+    start_sendrecv_suNg_field(out);
+    complete_sendrecv_suNg_field(out);
+#endif
 }
 
 int main(int argc, char *argv[]) {
@@ -86,12 +134,11 @@ int main(int argc, char *argv[]) {
     double p1, p2;
     double pdiff;
     double act;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     /* setup process communications */
     setup_process(&argc, &argv);
-
     setup_gauge_fields();
-
     gtransf *g = alloc_gtransf(&glattice);
     suNg_field *fixed_gauge = alloc_suNg_field(&glattice);
 
@@ -106,7 +153,7 @@ int main(int argc, char *argv[]) {
     start_sendrecv_gtransf(g);
     complete_sendrecv_gtransf(g);
 
-    p1 = calc_plaq(u_gauge);
+    p1 = avr_plaquette();
     lprintf("TEST", 0, "original gauge plaq %1.14f\n", p1);
 
     transform_u(fixed_gauge, u_gauge, g);
@@ -114,7 +161,7 @@ int main(int argc, char *argv[]) {
     complete_sendrecv_suNg_field(fixed_gauge);
 
     p2 = calc_plaq(fixed_gauge);
-    lprintf("TEST", 0, "plaq after random gauge tranforamtion %1.14f\n", p2);
+    lprintf("TEST", 0, "plaq after random gauge transformation %1.14f\n", p2);
     if (fabs(p1 - p2) > 1e-14) { return_value += 1; }
 
     pdiff = calc_plaq_diff(u_gauge, fixed_gauge);
@@ -130,12 +177,12 @@ int main(int argc, char *argv[]) {
     lprintf("TEST", 0, "action  %1.14f\n", act);
 
     p2 = calc_plaq(fixed_gauge);
-    lprintf("TEST", 0, "plaq after random gauge transformation  and gauge fixing %1.14f\n", p2);
+    lprintf("TEST", 0, "plaq after random gauge transformation and gauge fixing %1.14f\n", p2);
     if (fabs(p1 - p2) > 1e-14) { return_value += 1; }
 
     pdiff = calc_plaq_diff(u_gauge, fixed_gauge);
     if (fabs(pdiff) > 1e-14) { return_value += 1; }
-    lprintf("TEST", 0, "sum of difference of plaquettes original/gauge transformed  and gauge fixed field %1.14f\n", pdiff);
+    lprintf("TEST", 0, "sum of difference of plaquettes original/gauge transformed and gauge fixed field %1.14f\n", pdiff);
 
     lprintf("TEST", 0, "Perform test gauge invariance of the gauge fixing with a unit gauge field\n");
     // initialise unit gauge field
@@ -156,7 +203,7 @@ int main(int argc, char *argv[]) {
     complete_sendrecv_suNg_field(fixed_gauge);
 
     p2 = calc_plaq(fixed_gauge);
-    lprintf("TEST", 0, "plaq after random gauge tranforamtion %1.14f\n", p2);
+    lprintf("TEST", 0, "plaq after random gauge tranformation %1.14f\n", p2);
     if (fabs(p1 - p2) > 1e-14) { return_value += 1; }
 
     pdiff = calc_plaq_diff(u_gauge, fixed_gauge);
@@ -172,12 +219,12 @@ int main(int argc, char *argv[]) {
     lprintf("TEST", 0, "action  %1.14f\n", act);
 
     p2 = calc_plaq(fixed_gauge);
-    lprintf("TEST", 0, "plaq after random gauge transformation  and gauge fixing %1.14f\n", p2);
+    lprintf("TEST", 0, "plaq after random gauge transformation and gauge fixing %1.14f\n", p2);
     if (fabs(p1 - p2) > 1e-14) { return_value += 1; }
 
     pdiff = calc_plaq_diff(u_gauge, fixed_gauge);
     if (fabs(pdiff) > 1e-14) { return_value += 1; }
-    lprintf("TEST", 0, "sum of difference of plaquettes original/gauge transformed  and gauge fixed field %1.14f\n", pdiff);
+    lprintf("TEST", 0, "sum of difference of plaquettes original/gauge transformed and gauge fixed field %1.14f\n", pdiff);
 
     global_sum_int(&return_value, 1);
     lprintf("MAIN", 0, "return_value= %d\n ", return_value);

--- a/TestProgram/GaugeFix/check_gaugefix.c
+++ b/TestProgram/GaugeFix/check_gaugefix.c
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
     complete_sendrecv_suNg_field(fixed_gauge);
 
     p2 = calc_plaq(fixed_gauge);
-    lprintf("TEST", 0, "plaq after random gauge tranformation %1.14f\n", p2);
+    lprintf("TEST", 0, "plaq after random gauge transformation %1.14f\n", p2);
     if (fabs(p1 - p2) > 1e-14) { return_value += 1; }
 
     pdiff = calc_plaq_diff(u_gauge, fixed_gauge);

--- a/TestProgram/Mesons/check_triplets_1.c
+++ b/TestProgram/Mesons/check_triplets_1.c
@@ -99,6 +99,12 @@ int main(int argc, char *argv[]) {
     g[0] = g[1] = g[2] = g[3] = 0;
     pta_qprop_QMR_eo(g, pta_qprop, 1, &mass, 1e-28);
 
+#ifdef WITH_GPU
+    for (int k = 0; k < 4 * NF; k++) {
+        copy_from_gpu(pta_qprop[0] + k);
+    }
+#endif
+
     id_correlator(pta_triplets[A], g[0], pta_qprop[0]);
     g0_correlator(pta_triplets[Xt], g[0], pta_qprop[0]);
     g5_correlator(pta_triplets[Pi], g[0], pta_qprop[0]);

--- a/TestProgram/Sources/check_stoch_sources_1_spinor_field.c
+++ b/TestProgram/Sources/check_stoch_sources_1_spinor_field.c
@@ -90,6 +90,7 @@ int main(int argc, char *argv[]) {
     int b1, b2, c1, c2;
     int counter;
     hr_complex av_, sd_;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     logger_map("DEBUG", "debug");
     logger_setlevel(0, 200);

--- a/TestProgram/Sources/check_stoch_sources_4_spinor_field.c
+++ b/TestProgram/Sources/check_stoch_sources_4_spinor_field.c
@@ -99,6 +99,7 @@ int main(int argc, char *argv[]) {
     int col, tau, eo, j;
     int k, counter;
     hr_complex av_, sd_;
+    std_comm_t = ALL_COMMS; // Communications of both the CPU and GPU field copy are necessary
 
     logger_map("DEBUG", "debug");
     logger_setlevel(0, 200);

--- a/TestProgram/SpinorField/check_spinorfield_1.c
+++ b/TestProgram/SpinorField/check_spinorfield_1.c
@@ -31,6 +31,11 @@ static void alloc_ws_rotate(void) {
 
 static void rotate_ptr(int n, spinor_field *pkk[], hr_complex vl[]) {
     if (initr == 0) { alloc_ws_rotate(); }
+#ifdef WITH_GPU
+    for (int i = 0; i < n; i++) {
+        copy_from_gpu(pkk[i]);
+    }
+#endif
 
     error((n < 1) || (n > MAX_ROTATE), 1, "rotate [eva.c]", "Parameter n is out of range");
 
@@ -61,6 +66,12 @@ static void rotate_ptr(int n, spinor_field *pkk[], hr_complex vl[]) {
             *_FIELD_AT(pkk[k], ix) = psi[k];
         }
     }
+
+#ifdef WITH_GPU
+    for (int i = 0; i < n; i++) {
+        copy_to_gpu(pkk[i]);
+    }
+#endif
 }
 
 static void project(spinor_field *pk, spinor_field *pl) {


### PR DESCRIPTION
This adds the option to measure connected and disconnected contributions to correlation functions on the GPU. Note here, that only the inversion is actually performed on the GPU while contractions will be done on the CPU as before, mainly because they are not the performance bottleneck and it takes too much time at the moment to port them. 

The code has been tested using the available unit tests. I also ran this on a single configuration with N_c=2 fundamental and checked the output by eye. This PR means that the following tests are working and passing when compiled WITH_GPU

**As before**
1. Algebra
2. ComplexNumbers
3. DiracOperator
4. Geometry
5. Integrators
6. Inverters
7. LinearAlgebra
8. Memory
9. Update
10. Utils

**New tests with this PR**
1. Disconnected
2. GaugeFix
3. Mesons
4. Propagator
5. Sources
6. SpinorField
