### PR TITLE
Fixed memory leak in spectroscopy code

### DIFF
--- a/LibHR/Observables/calc_prop.c
+++ b/LibHR/Observables/calc_prop.c
@@ -150,6 +150,10 @@ void free_propagator_eo() {
         free_spinor_field(tmp_even);
         tmp_even = NULL;
     }
+    if (tmp_even2 != NULL) {
+        free_spinor_field(tmp_even2);
+        tmp_even2 = NULL;
+    }
     if (resd_even != NULL) {
         free_spinor_field(resd_even);
         resd_even = NULL;


### PR DESCRIPTION
For each configuration that is analyzed, there are temporary fields allocated in init_propagator_eo(), but not all of them are freed, so after analyzing a certain amount of configuration, the system runs out of memory.