### PR TITLE
Ensure compilation with newest architectures

### DIFF
--- a/Make/NinjaBuild.pl
+++ b/Make/NinjaBuild.pl
@@ -366,6 +366,11 @@ sub read_conf {
             
             # set linker
             unshift @{$options{'LINK'}}, "$nvcc --forward-unknown-to-host-compiler -ccbin"; 
+
+            my @arch = grep(/-arch/,@{$options{'GPUFLAGS'}}); # Check if architecture is specified by user
+            if (!@arch) {
+                push(@{$options{'GPUFLAGS'}},"-arch=all"); # If not specified by user compile fat binary
+            }
         } else {
             push(@{$options{'GPUFLAGS'}},"-xhip -fgpu-rdc");
             push(@{$options{'LDFLAGS'}},"-lstdc++ --hip-link");
@@ -374,6 +379,8 @@ sub read_conf {
             push(@{$options{'MACRO'}},"__HIP_PLATFORM_HCC__");
         }
         push(@{$options{'GPUFLAGS'}},"-std=c++17");
+
+
     }
 
     # add standard definitions to MACRO

--- a/Make/NinjaBuild.pl
+++ b/Make/NinjaBuild.pl
@@ -379,8 +379,6 @@ sub read_conf {
             push(@{$options{'MACRO'}},"__HIP_PLATFORM_HCC__");
         }
         push(@{$options{'GPUFLAGS'}},"-std=c++17");
-
-
     }
 
     # add standard definitions to MACRO


### PR DESCRIPTION
Whether compilation without specification of the architecture compiles to the newest architecture depends on the system settings. In HiRep, the user may specify the architecture in the GPUFLAGS when building, but ideally, they don't have to. There was a specific case for Tursa, where the fat binary compiled without specification of the architecture compiles only for compute capability 5.2, which causes issues with cub reductions. 

This was the origin of the issue in #126 

The suggestion below enforces the usage of -arch=all, but only if the user did not specify the target architecture.
I tested this by checking the build commands by eye using nj -v. 